### PR TITLE
Remove the ngrok reference

### DIFF
--- a/plugins/wp-chargify/includes/chargify/endpoints/webhooks.php
+++ b/plugins/wp-chargify/includes/chargify/endpoints/webhooks.php
@@ -105,7 +105,7 @@ function set_webhooks( $webhooks ) {
 
 	$data = [
 		'endpoint' => [
-			'url'                   => 'http://70b296211bca.ngrok.io/wp-json/chargify/v1/webhook',
+			'url'                   => home_url( '/wp-json/chargify/v1/webhook' ),
 			'webhook_subscriptions' => $webhooks
 		]
 	];


### PR DESCRIPTION
Ideally, the logger shouldn't require a request. Removing the request dependency would mean you don't have to simulate a request from Chargify to log settings changes.