### PR TITLE
Make Post title more unique

### DIFF
--- a/plugins/wp-chargify/includes/logging/logger.php
+++ b/plugins/wp-chargify/includes/logging/logger.php
@@ -18,7 +18,7 @@ function logger( $request_endpoint, $response_status, $response_headers, $type, 
 	$log_id = wp_insert_post(
 		[
 			'post_type'   => 'chargify_api_log',
-			'post_title'  =>  sanitize_text_field( $type ),
+			'post_title'  =>  sanitize_text_field( $type . '-' . date( 'Ymdhis' ) ),
 			'post_status' => 'publish',
 		]
 	);


### PR DESCRIPTION
Due to the way `wp_unique_slug` works, setting only a small amount of variation of post title can result in run-away SELECT queries, as the logs grow.

In an example seen recently, a site with 48k `webhook` events logged, resulted in around 25k select/second.